### PR TITLE
Updates to support etcd nodes on Digital Ocean

### DIFF
--- a/modules/digitalocean/etcd/dns.tf
+++ b/modules/digitalocean/etcd/dns.tf
@@ -1,26 +1,5 @@
-resource "aws_route53_record" "etcd_srv_discover" {
-  count = 1
-  name = "_etcd-server._tcp"
-  type = "SRV"
-  zone_id = "${var.dns_zone_id}"
-  records = ["${formatlist("0 0 2380 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
-  ttl = "300"
-}
-
-resource "aws_route53_record" "etcd_srv_client" {
-  count = 1
-  name = "_etcd-client._tcp"
-  type = "SRV"
-  zone_id = "${var.dns_zone_id}"
-  records = ["${formatlist("0 0 2379 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
-  ttl = "60"
-}
-
-resource "aws_route53_record" "etc_a_nodes" {
+resource "digitalocean_domain" "etc_a_nodes" {
   count = "${var.droplet_count}"
-  type = "A"
-  ttl = "60"
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.cluster_name}-etcd-${count.index}"
-  records = ["${digitalocean_droplet.etcd_node.*.ipv4_address[count.index]}"]
+  name       = "${var.cluster_name}-etcd-${count.index}.${var.base_domain}"
+  ip_address = "${digitalocean_droplet.etcd_node.*.ipv4_address[count.index]}"
 }

--- a/modules/digitalocean/etcd/nodes.tf
+++ b/modules/digitalocean/etcd/nodes.tf
@@ -5,6 +5,6 @@ resource "digitalocean_droplet" "etcd_node" {
   region = "fra1"
   size = "${var.droplet_size}"
   ssh_keys = ["${var.ssh_keys}"]
-  tags = ["${var.extra_tags}"]
+  #tags = ["${var.extra_tags}"]
   user_data = "${data.ignition_config.etcd.*.rendered[count.index]}"
 }

--- a/modules/digitalocean/etcd/resources/etcd-cluster
+++ b/modules/digitalocean/etcd/resources/etcd-cluster
@@ -1,0 +1,1 @@
+${etcd-name}=http://${etcd-address}:2380

--- a/platforms/digitalocean/main.tf
+++ b/platforms/digitalocean/main.tf
@@ -2,11 +2,6 @@ provider "digitalocean" {
   token = "${var.tectonic_do_token}"
 }
 
-provider "aws" {
-  region = "${var.tectonic_aws_region}"
-  profile = "${var.tectonic_aws_profile}"
-}
-
 module "etcd" {
   source = "../../modules/digitalocean/etcd"
 
@@ -17,5 +12,5 @@ module "etcd" {
   base_domain = "${var.tectonic_base_domain}"
   ssh_keys = "${var.tectonic_do_ssh_keys}"
   extra_tags = "${var.tectonic_do_extra_tags}"
-  dns_zone_id = "${aws_route53_zone.tectonic-int.zone_id}"
+  dns_zone_id = "${var.tectonic_base_domain}"
 }

--- a/platforms/digitalocean/route53.tf
+++ b/platforms/digitalocean/route53.tf
@@ -1,8 +1,0 @@
-resource "aws_route53_zone" "tectonic-int" {
-  name = "${var.tectonic_base_domain}"
-  force_destroy = true
-  tags = "${map(
-    "Name", "${var.tectonic_cluster_name}_tectonic_int_zone",
-    "KubernetesCluster", "${var.tectonic_cluster_name}"
-  )}"
-}

--- a/platforms/digitalocean/variables.tf
+++ b/platforms/digitalocean/variables.tf
@@ -39,15 +39,3 @@ variable "tectonic_do_extra_tags" {
   type = "list"
   default = []
 }
-
-variable "tectonic_aws_region" {
-  type = "string"
-  default = "eu-west-1"
-  description = "The target AWS region for DNS."
-}
-
-variable "tectonic_aws_profile" {
-  type = "string"
-  default = "default"
-  description = "AWS profile name as set in the shared credentials file."
-}


### PR DESCRIPTION
- remove Route53 dependency
- fixes https://github.com/coreos/tectonic-installer/issues/632 by changing the `--name=etcd` flag.
- uses DO DNS for DNS record creation